### PR TITLE
Update dependencies, gradle, kotlin, okhttp, min and target SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         // NOTE: Do not place your application dependencies here; they belong

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.unsplash.pickerandroid.example"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -26,12 +26,12 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':photopicker')
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0-alpha04'
-    implementation 'com.google.android.material:material:1.0.0'
-    implementation 'androidx.core:core-ktx:1.1.0-alpha05'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation 'com.squareup.picasso:picasso:2.71828'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jan 26 11:08:37 EST 2019
+#Tue Nov 30 22:04:47 PST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/photopicker/build.gradle
+++ b/photopicker/build.gradle
@@ -3,12 +3,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
-        versionCode 2
-        versionName "1.0.1"
+        targetSdkVersion 31
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -27,32 +25,32 @@ dependencies {
 
     // kotlin and android
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0-alpha04'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
+    implementation 'com.google.android.material:material:1.4.0'
 
     // retrofit and okhttp
-    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
-    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.4.0'
-    implementation 'com.squareup.retrofit2:converter-moshi:2.4.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
 
     // paging
-    implementation 'androidx.paging:paging-runtime:2.1.0'
-    implementation 'androidx.paging:paging-rxjava2:2.1.0'
+    implementation 'androidx.paging:paging-runtime-ktx:3.1.0'
+    implementation 'androidx.paging:paging-rxjava2-ktx:3.1.0'
 
     // misc
     implementation 'com.squareup.picasso:picasso:2.71828'
-    implementation 'com.jakewharton.rxbinding2:rxbinding:2.1.1'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
+    implementation 'com.jakewharton.rxbinding2:rxbinding:2.2.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.3'
 
     // lifecycle
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
-    kapt 'androidx.lifecycle:lifecycle-compiler:2.1.0-alpha04'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    annotationProcessor "androidx.lifecycle:lifecycle-common-java8:2.4.0"
 
     // test
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
 apply from: 'publish.gradle'

--- a/photopicker/src/main/java/com/unsplash/pickerandroid/photopicker/domain/LoadPhotoDataSource.kt
+++ b/photopicker/src/main/java/com/unsplash/pickerandroid/photopicker/domain/LoadPhotoDataSource.kt
@@ -29,16 +29,16 @@ class LoadPhotoDataSource(private val networkEndpoints: NetworkEndpoints) : Page
                     // do nothing on this terminal event
                 }
 
-                override fun onSubscribe(d: Disposable?) {
+                override fun onSubscribe(d: Disposable) {
                     // we don't keep the disposable
                 }
 
-                override fun onNext(response: Response<List<UnsplashPhoto>>?) {
+                override fun onNext(response: Response<List<UnsplashPhoto>>) {
                     // if the response is successful
                     // we get the last page number
                     // we push the result on the paging callback
                     // we update the network state to success
-                    if (response != null && response.isSuccessful) {
+                    if (response.isSuccessful) {
                         lastPage = response.headers().get("x-total")?.toInt()?.div(params.requestedLoadSize)
                         callback.onResult(response.body()!!, null, 2)
                         networkState.postValue(NetworkState.SUCCESS)
@@ -46,13 +46,13 @@ class LoadPhotoDataSource(private val networkEndpoints: NetworkEndpoints) : Page
                     // if the response is not successful
                     // we update the network state to error along with the error message
                     else {
-                        networkState.postValue(NetworkState.error(response?.message()))
+                        networkState.postValue(NetworkState.error(response.message()))
                     }
                 }
 
-                override fun onError(e: Throwable?) {
+                override fun onError(e: Throwable) {
                     // we update the network state to error along with the error message
-                    networkState.postValue(NetworkState.error(e?.message))
+                    networkState.postValue(NetworkState.error(e.message))
                 }
             })
     }
@@ -67,16 +67,16 @@ class LoadPhotoDataSource(private val networkEndpoints: NetworkEndpoints) : Page
                     // do nothing on this terminal event
                 }
 
-                override fun onSubscribe(d: Disposable?) {
+                override fun onSubscribe(d: Disposable) {
                     // we don't keep the disposable
                 }
 
-                override fun onNext(response: Response<List<UnsplashPhoto>>?) {
+                override fun onNext(response: Response<List<UnsplashPhoto>>) {
                     // if the response is successful
                     // we get the next page number
                     // we push the result on the paging callback
                     // we update the network state to success
-                    if (response != null && response.isSuccessful) {
+                    if (response.isSuccessful) {
                         val nextPage = if (params.key == lastPage) null else params.key + 1
                         callback.onResult(response.body()!!, nextPage)
                         networkState.postValue(NetworkState.SUCCESS)
@@ -84,13 +84,13 @@ class LoadPhotoDataSource(private val networkEndpoints: NetworkEndpoints) : Page
                     // if the response is not successful
                     // we update the network state to error along with the error message
                     else {
-                        networkState.postValue(NetworkState.error(response?.message()))
+                        networkState.postValue(NetworkState.error(response.message()))
                     }
                 }
 
-                override fun onError(e: Throwable?) {
+                override fun onError(e: Throwable) {
                     // we update the network state to error along with the error message
-                    networkState.postValue(NetworkState.error(e?.message))
+                    networkState.postValue(NetworkState.error(e.message))
                 }
             })
     }

--- a/photopicker/src/main/java/com/unsplash/pickerandroid/photopicker/domain/Repository.kt
+++ b/photopicker/src/main/java/com/unsplash/pickerandroid/photopicker/domain/Repository.kt
@@ -49,11 +49,11 @@ class Repository constructor(private val networkEndpoints: NetworkEndpoints) {
                     override fun onComplete() { /* do nothing */
                     }
 
-                    override fun onSubscribe(d: Disposable?) {  /* do nothing */
+                    override fun onSubscribe(d: Disposable) {  /* do nothing */
                     }
 
-                    override fun onError(e: Throwable?) {
-                        Log.e(Repository::class.java.simpleName, e?.message, e)
+                    override fun onError(e: Throwable) {
+                        Log.e(Repository::class.java.simpleName, e.message, e)
                     }
                 })
         }

--- a/photopicker/src/main/java/com/unsplash/pickerandroid/photopicker/domain/SearchPhotoDataSource.kt
+++ b/photopicker/src/main/java/com/unsplash/pickerandroid/photopicker/domain/SearchPhotoDataSource.kt
@@ -38,16 +38,16 @@ class SearchPhotoDataSource(
                     // do nothing on this terminal event
                 }
 
-                override fun onSubscribe(d: Disposable?) {
+                override fun onSubscribe(d: Disposable) {
                     // we don't keep the disposable
                 }
 
-                override fun onNext(response: Response<SearchResponse>?) {
+                override fun onNext(response: Response<SearchResponse>) {
                     // if the response is successful
                     // we get the last page number
                     // we push the result on the paging callback
                     // we update the network state to success
-                    if (response != null && response.isSuccessful) {
+                    if (response.isSuccessful) {
                         lastPage = response.headers().get("x-total")?.toInt()?.div(params.requestedLoadSize)
                         callback.onResult(response.body()?.results!!, null, 2)
                         networkState.postValue(NetworkState.SUCCESS)
@@ -55,13 +55,13 @@ class SearchPhotoDataSource(
                     // if the response is not successful
                     // we update the network state to error along with the error message
                     else {
-                        networkState.postValue(NetworkState.error(response?.message()))
+                        networkState.postValue(NetworkState.error(response.message()))
                     }
                 }
 
-                override fun onError(e: Throwable?) {
+                override fun onError(e: Throwable) {
                     // we update the network state to error along with the error message
-                    networkState.postValue(NetworkState.error(e?.message))
+                    networkState.postValue(NetworkState.error(e.message))
                 }
             })
     }
@@ -81,16 +81,16 @@ class SearchPhotoDataSource(
                     // do nothing on this terminal event
                 }
 
-                override fun onSubscribe(d: Disposable?) {
+                override fun onSubscribe(d: Disposable) {
                     // we don't keep the disposable
                 }
 
-                override fun onNext(response: Response<SearchResponse>?) {
+                override fun onNext(response: Response<SearchResponse>) {
                     // if the response is successful
                     // we get the next page number
                     // we push the result on the paging callback
                     // we update the network state to success
-                    if (response != null && response.isSuccessful) {
+                    if (response.isSuccessful) {
                         val nextPage = if (params.key == lastPage) null else params.key + 1
                         callback.onResult(response.body()?.results!!, nextPage)
                         networkState.postValue(NetworkState.SUCCESS)
@@ -102,9 +102,9 @@ class SearchPhotoDataSource(
                     }
                 }
 
-                override fun onError(e: Throwable?) {
+                override fun onError(e: Throwable) {
                     // we update the network state to error along with the error message
-                    networkState.postValue(NetworkState.error(e?.message))
+                    networkState.postValue(NetworkState.error(e.message))
                 }
             })
     }

--- a/photopicker/src/main/java/com/unsplash/pickerandroid/photopicker/presentation/BaseViewModel.kt
+++ b/photopicker/src/main/java/com/unsplash/pickerandroid/photopicker/presentation/BaseViewModel.kt
@@ -45,11 +45,11 @@ abstract class BaseViewModel : ViewModel() {
         override fun onComplete() {
         }
 
-        override fun onSubscribe(d: Disposable?) {
+        override fun onSubscribe(d: Disposable) {
             mCompositeDisposable.add(d)
         }
 
-        override fun onNext(value: Data?) {
+        override fun onNext(value: Data) {
             if (UnsplashPhotoPicker.isLoggingEnabled()) {
                 Log.i(getTag(), value.toString())
             }
@@ -59,8 +59,8 @@ abstract class BaseViewModel : ViewModel() {
             onSuccess(value)
         }
 
-        override fun onError(e: Throwable?) {
-            Log.e(getTag(), e?.message, e)
+        override fun onError(e: Throwable) {
+            Log.e(getTag(), e.message, e)
             // hiding the loading
             mLoadingLiveData.postValue(false)
             // posting the error


### PR DESCRIPTION
 - gradle wrapper 4.10.1 -> 7.0.2, plugin 3.3.2 -> 7.0.3
 - kotlin_version 1.3.11 -> 1.5.31
 - add android:exported="true" to the Manifest as it's required by SDK
 31
 - 'androidx.appcompat:appcompat:1.1.0-alpha04' -> 1.4.0
 - 'com.google.android.material:material:1.0.0' -> 1.4.0
 - 'androidx.core:core-ktx:1.1.0-alpha05' -> 1.7.0
 - 'androidx.constraintlayout:constraintlayout:1.1.3' -> 2.1.2
 - 'com.squareup.picasso:picasso:2.71828' ->
 - 'junit:junit:4.12' -> 4.13.2
 - 'androidx.test:runner:1.1.1' -> 1.4.0
 - 'androidx.test.espresso:espresso-core:3.1.1 -> 3.4.0
 - update observable methods to match nullability

 - 'com.google.android.material:material:1.0.0' -> 1.4.0

 - 'com.squareup.retrofit2:retrofit:2.4.0' -> 2.9.0
 - 'com.squareup.retrofit2:adapter-rxjava2:2.4.0' -> 2.9.0
 - 'com.squareup.retrofit2:converter-moshi:2.4.0' -> 2.9.0

 - 'androidx.paging:paging-runtime:2.1.0' -> ktx 3.1.0
 - 'androidx.paging:paging-rxjava2:2.1.0- -> ktx 3.1.0

 - 'com.jakewharton.rxbinding2:rxbinding:2.1.1' -> 2.2.0
 - 'com.squareup.okhttp3:logging-interceptor:3.11.0- -> 5.0.0-alpha.3

 - 'androidx.lifecycle:lifecycle-extensions:2.0.0' -> 2.2.0
 - 'androidx.lifecycle:lifecycle-compiler:2.1.0-alpha04- -> 2.4.0